### PR TITLE
[*] MO : bankwire remove wrong helper->id in bankwire.php

### DIFF
--- a/bankwire.php
+++ b/bankwire.php
@@ -248,7 +248,6 @@ class BankWire extends PaymentModule
 		$helper->default_form_language = $lang->id;
 		$helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
 		$this->fields_form = array();
-		$helper->id = (int)Tools::getValue('id_carrier');
 		$helper->identifier = $this->identifier;
 		$helper->submit_action = 'btnSubmit';
 		$helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false).'&configure='.$this->name.'&tab_module='.$this->tab.'&module_name='.$this->name;


### PR DESCRIPTION
remove useless line $helper->id = (int)Tools::getValue('id_carrier');
because id_carrier doesn't exist