### PR TITLE
MO : Deduction of amount already paid

### DIFF
--- a/bankwire.php
+++ b/bankwire.php
@@ -178,10 +178,11 @@ class BankWire extends PaymentModule
 			return;
 
 		$state = $params['objOrder']->getCurrentState();
+		$total_to_paid = $params['objOrder']->getOrdersTotalPaid() - $params['objOrder']->getTotalPaid();
 		if (in_array($state, array(Configuration::get('PS_OS_BANKWIRE'), Configuration::get('PS_OS_OUTOFSTOCK'), Configuration::get('PS_OS_OUTOFSTOCK_UNPAID'))))
 		{
 			$this->smarty->assign(array(
-				'total_to_pay' => Tools::displayPrice($params['total_to_pay'], $params['currencyObj'], false),
+				'total_to_pay' => Tools::displayPrice($total_to_paid, $params['currencyObj'], false),
 				'bankwireDetails' => Tools::nl2br($this->details),
 				'bankwireAddress' => Tools::nl2br($this->address),
 				'bankwireOwner' => $this->owner,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | An order can have other payment on the same order process we can have a payment that is made before (eg payment by gift card or balance / have), so it is necessary to deduct the amount that has already been paid. This update have visual impact for the final customer. I regularly implement this update near my clients.
Maybe one day we will be able to make multiple payments, this update is a first step :-).
| Type?         | Feature
| Category?     | MO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  |  Paid with bank wire and check if amount is good.
